### PR TITLE
Optimze map generation

### DIFF
--- a/cutter/tasks.py
+++ b/cutter/tasks.py
@@ -290,6 +290,7 @@ def output_turfs(form):
             make_img_file(cluster,folder_name)
             #Put the image file onto the PDF
             add_img(pdf,cluster,folder_name,w=150)
+        make_img_file.driver.quit()
 
 
         #Save the PDF

--- a/cutter/utilities/output.py
+++ b/cutter/utilities/output.py
@@ -6,9 +6,9 @@ import zipfile
 import gmplot
 import numpy as np
 from fpdf import FPDF
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
-from selenium import webdriver
 from pyvirtualdisplay import Display
+from selenium import webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 
 #Convert a folder to a zip file
@@ -50,16 +50,19 @@ def make_html_file(df,folder):
 #We are opening it in a browser and taking a screenshot
 #So if there's a better way that is preferable
 def make_img_file(cluster,folder):
-    #display = Display(visible=0, size=(800, 800))  
-    #display.start()
-    #Have a virtual Chrome driver open the html file
-    chrome_options = webdriver.ChromeOptions()
-    chrome_options.add_argument('headless')
-    chrome_options.add_argument('no-sandbox')
-    driver = webdriver.Chrome(chrome_options=chrome_options)   
-    #driver = webdriver(\
-        #command_executor='http://172.19.0.5:4444/wd/hub',\
-        #desired_capabilities=DesiredCapabilities.CHROME)   
+    driver = getattr(make_img_file, 'driver', None)
+    if not driver:
+        #display = Display(visible=0, size=(800, 800))
+        #display.start()
+        #Have a virtual Chrome driver open the html file
+        chrome_options = webdriver.ChromeOptions()
+        chrome_options.add_argument('headless')
+        chrome_options.add_argument('no-sandbox')
+        driver = webdriver.Chrome(chrome_options=chrome_options)
+        #driver = webdriver(\
+            #command_executor='http://172.19.0.5:4444/wd/hub',\
+            #desired_capabilities=DesiredCapabilities.CHROME)
+        make_img_file.driver = driver
     cwd = os.getcwd()
 
     driver.get("file://{cwd}/{folder}/temp_map.html".format(cwd=cwd,folder=folder))
@@ -67,7 +70,6 @@ def make_img_file(cluster,folder):
     time.sleep(4)      
     #Save the screenshot as a file
     driver.get_screenshot_as_file("{folder}/temp_map_{cluster}.png".format(cluster=cluster,folder=folder))
-    driver.quit()
 
 
 #Add an image to a specified pdf file


### PR DESCRIPTION
I did some profiling and determined two sources areas where there was a lot of time usage in make_img_file, one was from the 4 second sleep and the other from creating and destroying the browser driver each time.  These two commits fix both of these issues.  One small thing to note, I've noticed that usually the first couple of generated maps are missing or don't have fully loaded some of the map icons.  I think this is actually the way all of them should be (the maps are static images and don't need the icons).  Loaded or not loaded they don't make much of a difference in terms of usability.  From these two changes, I've seen turf generation time go from 325 seconds to 250 seconds or a decrease of about 25%.